### PR TITLE
Add mining share stats + branding + bugfixes

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -36,6 +36,28 @@
 
         </div>
 
+        <div class="col-12 lg:col-6 xl:col-3">
+            <div class="card mb-4">
+                <div class="flex justify-content-between mb-3">
+                    <div>
+                        <span class="block text-500 font-medium mb-3">Total Shares</span>
+                        <div class="text-900 font-medium text-xl">
+                            <ng-container *ngIf="totalShares$ | async as totalShares; else loading">
+                                {{totalShares | number}}
+                            </ng-container>
+                            <ng-template #loading>
+                                <p-skeleton></p-skeleton>
+                            </ng-template>
+                        </div>
+                    </div>
+                    <div class="flex align-items-center justify-content-center bg-green-100 border-round" [ngStyle]="{width: '2.5rem', height: '2.5rem'}">
+                        <i class="pi pi-sort-numeric-up text-green-500 text-xl"></i>
+                    </div>
+                </div>
+                <span class="text-green-500 font-medium">&nbsp;</span>
+            </div>
+        </div>
+
         <ng-container>
             <div class="col-12 lg:col-6 xl:col-3">
                 <div class="card mb-4">
@@ -120,6 +142,7 @@
                         <th>Session ID</th>
                         <th>Hash Rate</th>
                         <th>Session Best Difficulty</th>
+                        <th>Total Shares</th>
                         <th>Uptime</th>
                         <th>Last Seen</th>
                     </tr>
@@ -146,6 +169,9 @@
                             {{getBestDifficulty(worker.name, clientInfo.workers) | numberSuffix}}
                         </td>
                         <td>
+                            <ng-container *ngIf="workerShares$ | async as workerShares">{{getWorkerShares(worker.name, workerShares) | number}}</ng-container>
+                        </td>
+                        <td>
 
                         </td>
                         <td></td>
@@ -159,6 +185,7 @@
                         <td>{{worker.sessionId}}</td>
                         <td>{{worker.hashRate | hashSuffix}}</td>
                         <td>{{worker.bestDifficulty | numberSuffix}}</td>
+                        <td></td>
                         <td>{{worker.startTime | dateAgo}}</td>
                         <td>{{worker.lastSeen | dateAgo}}</td>
                     </tr>
@@ -179,6 +206,7 @@
                         <th>Session ID</th>
                         <th>Hash Rate</th>
                         <th>Session Best Difficulty</th>
+                        <th>Total Shares</th>
                         <th>Uptime</th>
                         <th>Last Seen</th>
                     </tr>
@@ -200,6 +228,10 @@
                         </td>
                         <td>
                             <p-skeleton></p-skeleton>
+                        </td>
+                        <td>
+                            <p-skeleton></p-skeleton>
+                        </td>
                         <td>
                             <p-skeleton></p-skeleton>
                         </td>
@@ -214,6 +246,7 @@
                 <ng-template pTemplate="rowexpansion" let-worker>
                     <tr>
                         <td></td>
+                        <td><p-skeleton></p-skeleton></td>
                         <td><p-skeleton></p-skeleton></td>
                         <td><p-skeleton></p-skeleton></td>
                         <td><p-skeleton></p-skeleton></td>

--- a/src/app/components/splash/splash.component.ts
+++ b/src/app/components/splash/splash.component.ts
@@ -240,15 +240,16 @@ export class SplashComponent implements OnInit, AfterViewInit {
   }
 
   fetchCommitInfo(): void {
-    this.http.get('/commit.txt', { responseType: 'text' }).subscribe({
-      next: (data) => {
-        this.commitInfo = data;
-        this.cdr.detectChanges();
-      },
-      error: () => {
-        this.commitInfo = 'Version info unavailable';
-        this.cdr.detectChanges();
-      }
-    });
-  }
+     const timestamp = Date.now();
+     this.http.get(`/commit.txt?t=${timestamp}`, { responseType: 'text' }).subscribe({
+       next: (data) => {
+         this.commitInfo = data;
+         this.cdr.detectChanges();
+       },
+       error: () => {
+         this.commitInfo = 'Version info unavailable';
+         this.cdr.detectChanges();
+       }
+     });
+   }
 }

--- a/src/app/layout/app.topbar.component.html
+++ b/src/app/layout/app.topbar.component.html
@@ -1,7 +1,7 @@
 <div class="layout-topbar">
     <a class="layout-topbar-logo" routerLink="">
-        <img src="assets/layout/images/logo.svg" alt="logo">
-        <span>Public Pool</span>
+        <img src="assets/layout/images/blitzpool-round.svg" alt="logo">
+        <span>Blitzpool</span>
     </a>
 
     <button #menubutton class="p-link layout-menu-button layout-topbar-button" (click)="layoutService.onMenuToggle()">

--- a/src/app/services/client.service.ts
+++ b/src/app/services/client.service.ts
@@ -19,4 +19,12 @@ export class ClientService {
   public getClientInfoChart(address: string) {
     return this.httpClient.get(`${environment.API_URL}/api/client/${address}/chart`) as Observable<any[]>;
   }
+
+  public getTotalShares(address: string) {
+    return this.httpClient.get(`${environment.API_URL}/api/client/${address}/shares`) as Observable<{ totalShares: number }>;
+  }
+
+  public getWorkerShares(address: string) {
+    return this.httpClient.get(`${environment.API_URL}/api/client/${address}/worker-shares`) as Observable<{ workerName: string, totalShares: number }[]>;
+  }
 }


### PR DESCRIPTION
## Summary
- expose new API methods for getting share counts
- show total share count card on dashboard
- display per-worker share totals in mining table
- handle parsing of best difficulty correctly
- dont cache server commit
- add own branding to dashboard
