### PR TITLE
Display average hashrate on splash page

### DIFF
--- a/src/app/components/splash/splash.component.html
+++ b/src/app/components/splash/splash.component.html
@@ -99,6 +99,11 @@
             <div class="card chart">
 
                 <div class="text-center mb-2">Uptime: {{uptime$ | async | dateAgo}}</div>
+                <div class="text-center mb-2">
+                    <ng-container *ngFor="let avg of averageHashrates; let last = last">
+                        <b>{{avg.period}}:</b> {{avg.value | hashSuffix}}<span *ngIf="!last"> | </span>
+                    </ng-container>
+                </div>
 
                 <ng-container *ngIf="chartData$ | async as chartData; else loadingChart">
 


### PR DESCRIPTION
## Summary
- compute average hashrate for several time ranges in `SplashComponent`
- expose those averages above the chart on the splash page

## Testing
- `npx ng test --watch=false` *(fails: ng not found / npm 403)*

------
https://chatgpt.com/codex/tasks/task_e_6846bd0f0eac832e85a837658d3aa3ea