### PR TITLE
Add halving estimate card

### DIFF
--- a/src/app/components/difficulty-adjustment/difficulty-adjustment.component.html
+++ b/src/app/components/difficulty-adjustment/difficulty-adjustment.component.html
@@ -8,4 +8,11 @@
       <p><strong>Days Until Adjustment:</strong> <span>{{ estimatedDaysUntilAdjustment }}</span> days</p>
     </div>
   </div>
+  <div class="col-12 md:col-6">
+    <div class="card text-center">
+      <h4>Estimated time until next halving</h4>
+      <p><strong>Blocks Remaining:</strong> <span>{{ halvingBlocksRemaining }}</span></p>
+      <p><strong>ETA:</strong> <span>{{ halvingEta }}</span></p>
+    </div>
+  </div>
 </div>

--- a/src/app/components/difficulty-adjustment/difficulty-adjustment.component.spec.ts
+++ b/src/app/components/difficulty-adjustment/difficulty-adjustment.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { DifficultyAdjustmentComponent } from './difficulty-adjustment.component';
 
@@ -8,7 +9,8 @@ describe('DifficultyAdjustmentComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DifficultyAdjustmentComponent ]
+      declarations: [ DifficultyAdjustmentComponent ],
+      imports: [ HttpClientTestingModule ]
     })
     .compileComponents();
 

--- a/src/app/components/difficulty-adjustment/difficulty-adjustment.component.ts
+++ b/src/app/components/difficulty-adjustment/difficulty-adjustment.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectorRef, Component, NgZone, OnInit } from '@angular/core';
+import { HalvingService } from '../../services/halving.service';
 
 @Component({
   selector: 'app-difficulty-adjustment',
@@ -11,12 +12,19 @@ export class DifficultyAdjustmentComponent implements OnInit {
   public currentHashrate: number | string = 'Loading...';
   public difficultyChange: string = 'Loading...';
   public estimatedDaysUntilAdjustment: string = 'Loading...';
+  public halvingBlocksRemaining: number | string = 'Loading...';
+  public halvingEta: string = 'Loading...';
 
-  constructor(private ngZone: NgZone, private cdr: ChangeDetectorRef) { }
+  constructor(
+    private ngZone: NgZone,
+    private cdr: ChangeDetectorRef,
+    private halvingService: HalvingService
+  ) { }
 
   ngOnInit(): void {
     this.fetchPoolStats();
     this.fetchDifficultyAdjustment();
+    this.fetchHalvingEstimate();
   }
 
   async fetchPoolStats() {
@@ -51,6 +59,23 @@ export class DifficultyAdjustmentComponent implements OnInit {
       this.ngZone.run(() => {
         this.difficultyChange = 'Error';
         this.estimatedDaysUntilAdjustment = 'Error';
+      });
+    }
+    this.cdr.detectChanges();
+  }
+
+  async fetchHalvingEstimate() {
+    try {
+      const data = await this.halvingService.getHalvingEstimate();
+      this.ngZone.run(() => {
+        this.halvingBlocksRemaining = data.blocksRemaining;
+        this.halvingEta = data.eta;
+      });
+    } catch (error) {
+      console.error('Error fetching halving estimate:', error);
+      this.ngZone.run(() => {
+        this.halvingBlocksRemaining = 'Error';
+        this.halvingEta = 'Error';
       });
     }
     this.cdr.detectChanges();

--- a/src/app/services/halving.service.ts
+++ b/src/app/services/halving.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class HalvingService {
+  private readonly HALVING_INTERVAL = 210000;
+  private readonly SECONDS_PER_BLOCK = 600;
+
+  constructor(private http: HttpClient) {}
+
+  async getHalvingEstimate(): Promise<{ blocksRemaining: number; eta: string }> {
+    const heightRes: any = await firstValueFrom(
+      this.http.get('https://mempool.space/api/blocks/tip/height')
+    );
+    const currentHeight = parseInt(heightRes, 10);
+
+    const nextHalvingHeight =
+      Math.ceil(currentHeight / this.HALVING_INTERVAL) * this.HALVING_INTERVAL;
+    const blocksRemaining = nextHalvingHeight - currentHeight;
+    const secondsRemaining = blocksRemaining * this.SECONDS_PER_BLOCK;
+
+    const etaDate = new Date(Date.now() + secondsRemaining * 1000);
+    return {
+      blocksRemaining,
+      eta: etaDate.toLocaleString('de-CH'),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a service for fetching the next halving estimate
- show estimated halving information on the Next Difficulty Adj page
- update unit test with HttpClientTestingModule

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a269b504832eab08426a42d03e2e